### PR TITLE
explicitly set content-type header for GraphQL request

### DIFF
--- a/src/util/fetch.ts
+++ b/src/util/fetch.ts
@@ -1,5 +1,8 @@
 export async function fetchGraphQLDataJSON(url: string, query: string) {
     const response = await fetch(url, {
+        headers: {
+          'Content-Type': 'application/json;charset=utf-8'
+        },
         method: 'POST',
         body: JSON.stringify({query: query})
       });


### PR DESCRIPTION
I ran into some cases where the content-type header in the GraphQL request was set to `text/plain` instead of `application/json`. This PR explicitly sets the content-type header to `application/json` for every GraphQL request.